### PR TITLE
Fixes reorder_suite import error

### DIFF
--- a/nose2django/nose2django.py
+++ b/nose2django/nose2django.py
@@ -17,7 +17,13 @@ class DjangoConfig(Plugin):
         Init the django environ and re-order the tests according to
         the django documented test runner behaviour.
         """
-        from django.test.simple import reorder_suite, DjangoTestSuiteRunner
+        try:
+            # Django >= 1.6
+            from django.test.runner import reorder_suite
+        except ImportError:
+            # Django < 1.6
+            from django.test.simple import reorder_suite
+        from django.test.simple import DjangoTestSuiteRunner
         from django.test.utils import setup_test_environment
         # Init the django default runner so we can call it's functions as needed
         self.dtsr = DjangoTestSuiteRunner()


### PR DESCRIPTION
Django 1.6 moved the reorder_suite function from django.test.simple to django.test.runner. This patch adds support for both.

[Fixes #2]
